### PR TITLE
Add Page Limit Test

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,8 +18,8 @@ jobs:
       with:
         root_file: resume.tex
 
-    - name: Check pdfinfo version
-      run: pdfinfo -v
+    - name: Install pdfinfo
+      run: sudo apt-get update && sudo apt-get install poppler-utils
 
     - name: Check number of pages
       run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,6 +18,14 @@ jobs:
       with:
         root_file: resume.tex
 
+    - name: Check number of pages
+      run: |
+        PAGES=$(pdfinfo resume.pdf | grep Pages | awk '{print $2}')
+        if [ "$PAGES" -gt 1 ]; then
+          echo "PDF has $PAGES pages, which is more than 1."
+          exit 1
+        fi
+
     - name: Upload PDF file
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         root_file: resume.tex
 
+    - name: Check pdfinfo version
+      run: pdfinfo -v
+
     - name: Check number of pages
       run: |
         PAGES=$(pdfinfo resume.pdf | grep Pages | awk '{print $2}')


### PR DESCRIPTION
Fix #3 

**Notes**
- `pdfinfo` is used instead of `pdftk` because to get number of pages, `pdfinfo` suffices.
  - `pdfinfo`: Provides metadata and information about PDF files.
  - `pdftk`: Manipulates PDF files, e.g., merging multiple PDF files, splitting PDF files into individual pages, rotating pages, decrypting and encrypting PDFs, adding watermarks, filling in PDF forms, etc.
- `pdfinfo` is not installed by default in `ubuntu-latest` runners, default software installed can be found [here](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md).